### PR TITLE
Update drv_cfg path for scaleio

### DIFF
--- a/.build/bintray-decapitate.sh
+++ b/.build/bintray-decapitate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BINTRAY_ACCOUNT=emccode
+BINTRAY_ACCOUNT=clintonskitson
 BINTRAY_REPO=rexray
 BINTRAY_URL=https://api.bintray.com/content/$BINTRAY_ACCOUNT/$BINTRAY_REPO
 BINTRAY_URL_STABLE=$BINTRAY_URL/stable/latest

--- a/.build/bintray-stable.json
+++ b/.build/bintray-stable.json
@@ -2,7 +2,7 @@
    "package": {
         "name": "stable",
         "repo": "rexray",
-        "subject": "emccode"
+        "subject": "clintonskitson"
     },
 
     "version": {

--- a/.build/bintray-staged.json
+++ b/.build/bintray-staged.json
@@ -2,7 +2,7 @@
    "package": {
         "name": "staged",
         "repo": "rexray",
-        "subject": "emccode"
+        "subject": "clintonskitson"
     },
 
     "version": {

--- a/.build/bintray-stupid.json
+++ b/.build/bintray-stupid.json
@@ -2,7 +2,7 @@
    "package": {
         "name": "unstable",
         "repo": "rexray",
-        "subject": "emccode"
+        "subject": "clintonskitson"
     },
 
     "version": {

--- a/.build/install
+++ b/.build/install
@@ -44,7 +44,7 @@ PROD=REX-Ray
 REPO=rexray
 BIN_NAME=rexray
 
-BINTRAY_URL=https://dl.bintray.com/emccode
+BINTRAY_URL=https://dl.bintray.com/clintonskitson
 URL=$BINTRAY_URL/$REPO
 
 SCRIPT_URL=$URL/install

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'emccode/rexray' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
+      condition: $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'clintonskitson/rexray' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
 
   - provider: bintray
     file: .build/bintray-staged-filtered.json
@@ -37,7 +37,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'emccode/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'clintonskitson/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
 
   - provider: bintray
     file: .build/bintray-stable-filtered.json
@@ -46,7 +46,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'emccode/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'clintonskitson/rexray' || $IGNORE_REPO_SLUG_CONDITION = true)
 
 cache:
   apt: true

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,8 +20,8 @@ import:
     repo:    https://github.com/clintonskitson/goamz
     vcs:     git
   - package: github.com/emccode/goscaleio
-    ref:     ff8bf10008603307944f5b14cc2bc21bc6b411b2
-    repo:    https://github.com/emccode/goscaleio.git
+    ref:     c2678d5574d90eb9104bb9f34e6a3fe03b6ef2c4
+    repo:    https://github.com/clintonskitson/goscaleio.git
     vcs:     git
   - package: github.com/emccode/goxtremio
     ref:     89e87d4bdf43837a161fd36ad8dd32e0ce42ae98


### PR DESCRIPTION
This update ensures that drv_cfg path works for standard linux
distributions as well as coreos.
